### PR TITLE
use timeout instead of recursion to avoid maximum call stack errors

### DIFF
--- a/inc/jquery.mb.audio.js
+++ b/inc/jquery.mb.audio.js
@@ -236,7 +236,9 @@ function supportType(audioType) {
 				player.currentTime = sprite.start;
 
 				if (Math.round(player.currentTime) != Math.round(sprite.start)){
-					checkStart(player, sID, sound, sprite, callback);
+					setTimeout(function() {
+						checkStart(player, sID, sound, sprite, callback);
+					}, 5);
 				}else{
 					playerPlay(player, sID, sound, sprite, callback);
 				}


### PR DESCRIPTION
We found in our tests that certain devices (e.g. Mobile Chrome Browser) would get stuck in a recursive loop leading to a stack overflow. Either due to the speed of the device, or the connection, it would loop too many times.

This proposed change gives some breathing room to the JavaScript engine by looping with `setTimeout` instead of recursion.
